### PR TITLE
Replace REQUIRE by Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,29 @@
+name = "VisualRegressionTests"
+uuid = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
+author = "Thomas Breloff"
+version = "0.3.1"
+
+[deps]
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
+
+[targets]
+test = ["Pkg", "Test", "Plots", "TestImages"]
+
+[compat]
+ColorTypes = "≥ 0.7.4"
+ColorVectorSpace = "≥ 0.6.1"
+FileIO = "≥ 1.0.1"
+ImageFiltering = "≥ 0.4.1"
+julia = "1"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,0 @@
-julia 0.7
-FileIO 1.0.1
-ColorTypes 0.7.4
-ColorVectorSpace 0.6.1
-ImageFiltering 0.4.1
-@windows ImageMagick
-@linux ImageMagick
-@osx QuartzImageIO
-Requires

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-TestImages
-Plots


### PR DESCRIPTION
I appreciate if you can review this PR and merge as soon as possible. I believe VisualRegressionTests.jl is holding some of my package tests somehow because of the old REQUIRE system.