### PR TITLE
Fix for deprecation warning

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,7 +21,7 @@ function blurdiff(A::AbstractArray, B::AbstractArray, sigma)
     Af = imfilter(A, kern, NA())
     Bf = imfilter(B, kern, NA())
     d = sad(Af, Bf)
-    diffscale = max(_abs(maxabsfinite(A)), _abs(maxabsfinite(B)))
+    diffscale = max(_abs(maximum_finite(abs, A)), _abs(maximum_finite(abs, B)))
     diffpct = d / (length(Af) * diffscale)
 
     diffpct


### PR DESCRIPTION
```julia
┌ Warning: `maxabsfinite(A; kwargs...)` is deprecated, use `maximum_finite(abs, A; kwargs...)` instead.
│   caller = blurdiff(A::Matrix{RGB{FixedPointNumbers.N0f8}}, B::Matrix{RGB{FixedPointNumbers.N0f8}}, sigma::Vector{Int64}) at utils.jl:24
└ @ VisualRegressionTests [...]/VisualRegressionTests.jl/src/utils.jl:24
```